### PR TITLE
[Port] Validate embedded errors for multipart upload. 

### DIFF
--- a/aws-cpp-sdk-core/include/aws/core/AmazonWebServiceRequest.h
+++ b/aws-cpp-sdk-core/include/aws/core/AmazonWebServiceRequest.h
@@ -14,6 +14,7 @@
 #include <aws/core/utils/memory/stl/AWSStreamFwd.h>
 #include <aws/core/utils/stream/ResponseStream.h>
 #include <aws/core/auth/AWSAuthSigner.h>
+#include <aws/core/client/CoreErrors.h>
 
 namespace Aws
 {
@@ -74,6 +75,15 @@ namespace Aws
          * Defaults to true, if this is set to false, then signers, if they support body signing, will not do so
          */
         virtual bool SignBody() const { return true; }
+
+        /**
+         * Defaults to false, if a derived class returns true it indicates that the body has an embedded error.
+         */
+        virtual bool HasEmbeddedError(Aws::IOStream& body, const Aws::Http::HeaderValueCollection& header) const {
+            (void) body;
+            (void) header;
+            return false;
+        }
 
         /**
          * Defaults to false, if this is set to true, it supports chunked transfer encoding.

--- a/aws-cpp-sdk-core/source/client/AWSClient.cpp
+++ b/aws-cpp-sdk-core/source/client/AWSClient.cpp
@@ -488,6 +488,14 @@ HttpResponseOutcome AWSClient::AttemptOneRequest(const std::shared_ptr<HttpReque
         return HttpResponseOutcome(std::move(error));
     }
 
+    if (request.HasEmbeddedError(httpResponse->GetResponseBody(), httpResponse->GetHeaders()))
+    {
+        AWS_LOGSTREAM_DEBUG(AWS_CLIENT_LOG_TAG, "Request returned error. Attempting to generate appropriate error codes from response");
+        auto error = BuildAWSError(httpResponse);
+        error.SetMessage(error.GetMessage() + " Error is embedded in the response body.");
+        return HttpResponseOutcome(std::move(error));
+    }
+
     AWS_LOGSTREAM_DEBUG(AWS_CLIENT_LOG_TAG, "Request returned successful response.");
 
     return HttpResponseOutcome(std::move(httpResponse));

--- a/aws-cpp-sdk-s3/include/aws/s3/model/CompleteMultipartUploadRequest.h
+++ b/aws-cpp-sdk-s3/include/aws/s3/model/CompleteMultipartUploadRequest.h
@@ -42,6 +42,7 @@ namespace Model
 
     Aws::Http::HeaderValueCollection GetRequestSpecificHeaders() const override;
 
+    bool HasEmbeddedError(IOStream &body, const Http::HeaderValueCollection &header) const override;
 
     /**
      * <p>Name of the bucket to which the multipart upload was initiated.</p>

--- a/aws-cpp-sdk-s3/source/model/CompleteMultipartUploadRequest.cpp
+++ b/aws-cpp-sdk-s3/source/model/CompleteMultipartUploadRequest.cpp
@@ -39,7 +39,7 @@ bool CompleteMultipartUploadRequest::HasEmbeddedError(Aws::IOStream &body,
 
   if (!doc.WasParseSuccessful()) {
     body.seekg(readPointer);
-    return false;
+    return true;
   }
 
   if (doc.GetRootElement().GetName() == "Error") {

--- a/aws-cpp-sdk-s3/source/model/CompleteMultipartUploadRequest.cpp
+++ b/aws-cpp-sdk-s3/source/model/CompleteMultipartUploadRequest.cpp
@@ -28,6 +28,28 @@ CompleteMultipartUploadRequest::CompleteMultipartUploadRequest() :
 {
 }
 
+bool CompleteMultipartUploadRequest::HasEmbeddedError(Aws::IOStream &body,
+  const Aws::Http::HeaderValueCollection &header) const
+{
+  // Header is unused
+  (void) header;
+
+  auto readPointer = body.tellg();
+  XmlDocument doc = XmlDocument::CreateFromXmlStream(body);
+
+  if (!doc.WasParseSuccessful()) {
+    body.seekg(readPointer);
+    return false;
+  }
+
+  if (doc.GetRootElement().GetName() == "Error") {
+    body.seekg(readPointer);
+    return true;
+  }
+  body.seekg(readPointer);
+  return false;
+}
+
 Aws::String CompleteMultipartUploadRequest::SerializePayload() const
 {
   XmlDocument payloadDoc = XmlDocument::CreateWithRootNode("CompleteMultipartUpload");


### PR DESCRIPTION
Port of https://github.com/aws/aws-sdk-cpp/pull/2057/files#diff-d7bd2c5a35fe1863a449cf248e80544c51ec00fedcbf0f2255b31fb2ea0066d2

`CompleteMultipartUpload` has been known to have errors in the body after a successful return of 200. This change updates for `CompleteMultipartUpload` to check the body for an error.

[S3 documentation](https://docs.aws.amazon.com/AmazonS3/latest/API/API_CompleteMultipartUpload.html)


https://packboard.atlassian.net/browse/FIR-22257