### PR TITLE
feat: gate IRSA through FIREBOLT_ALLOW_AWS_IRSA environment variable

### DIFF
--- a/src/aws-cpp-sdk-core/source/internal/AWSHttpResourceClient.cpp
+++ b/src/aws-cpp-sdk-core/source/internal/AWSHttpResourceClient.cpp
@@ -406,7 +406,6 @@ namespace Aws
 
         void InitEC2MetadataClient()
         {
-            #if 0
             if (s_ec2metadataClient)
             {
                 return;
@@ -444,7 +443,6 @@ namespace Aws
             }
             AWS_LOGSTREAM_INFO(EC2_METADATA_CLIENT_LOG_TAG, "Using IMDS endpoint: " << ec2MetadataServiceEndpoint);
             s_ec2metadataClient = Aws::MakeShared<EC2MetadataClient>(EC2_METADATA_CLIENT_LOG_TAG, ec2MetadataServiceEndpoint.c_str());
-            #endif
         }
 
         void CleanupEC2MetadataClient()

--- a/src/aws-cpp-sdk-core/source/internal/AWSHttpResourceClient.cpp
+++ b/src/aws-cpp-sdk-core/source/internal/AWSHttpResourceClient.cpp
@@ -406,6 +406,11 @@ namespace Aws
 
         void InitEC2MetadataClient()
         {
+            // IRSA (EC2 metadata-based credentials) is opt-in via FIREBOLT_ALLOW_AWS_IRSA.
+            if (!Aws::Utils::StringUtils::ConvertToBool(Aws::Environment::GetEnv("FIREBOLT_ALLOW_AWS_IRSA").c_str()))
+            {
+                return;
+            }
             if (s_ec2metadataClient)
             {
                 return;


### PR DESCRIPTION
# Description

Gate IRSA through `FIREBOLT_ALLOW_AWS_IRSA` environment variable.

# Issue

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it removes substantial `CI/` release-pipeline CloudFormation/buildspec/Lambda assets and changes GitHub Actions behavior (issue staleness thresholds, merge-time blocking, license scanning), which could disrupt existing maintenance/release workflows if still in use.
> 
> **Overview**
> **Modernizes repo automation/configuration and cleans up legacy CI assets.** Adds repo-wide lint/spellcheck configs via `.clang-tidy` and `.cspell.json`, updates the `cspell` GitHub Action invocation, and switches GitHub issue templates to the newer YAML form with `config.yml` to route questions to Discussions.
> 
> **Expands GitHub Actions governance/maintenance.** Introduces workflows for license-diff scanning on PRs plus a scheduled license check, a scheduled `handle-stale-discussions` job, and a `time-blocker` that prevents merges to `main` during a defined UTC window; also tweaks `stale_issue.yml` timings/messages.
> 
> **Removes legacy release infrastructure and updates housekeeping.** Deletes large portions of old `CI/` pipelines (binary release + Trebuchet release templates/buildspecs/Lambdas, Dockerfiles, install-test), adds a CRT submodule in `.gitmodules`, updates `.gitignore` paths/artifacts, and extends `CHANGELOG.md` with newer breaking-change entries.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 00153bf743b8167e303d7226df287f4102113720. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->