### PR TITLE
refactor: rename env var to FB_AWS_EC2_METADATA_CLIENT_ENABLED

### DIFF
--- a/src/aws-cpp-sdk-core/source/internal/AWSHttpResourceClient.cpp
+++ b/src/aws-cpp-sdk-core/source/internal/AWSHttpResourceClient.cpp
@@ -406,8 +406,11 @@ namespace Aws
 
         void InitEC2MetadataClient()
         {
-            // IRSA (EC2 metadata-based credentials) is opt-in via FIREBOLT_ALLOW_AWS_IRSA.
-            if (!Aws::Utils::StringUtils::ConvertToBool(Aws::Environment::GetEnv("FIREBOLT_ALLOW_AWS_IRSA").c_str()))
+            // The EC2 metadata client (used to fetch instance identity and IRSA-style
+            // credentials from the IMDS endpoint at 169.254.169.254) is disabled by
+            // default and must be explicitly enabled by setting
+            // FB_AWS_EC2_METADATA_CLIENT_ENABLED to a truthy value.
+            if (!Aws::Utils::StringUtils::ConvertToBool(Aws::Environment::GetEnv("FB_AWS_EC2_METADATA_CLIENT_ENABLED").c_str()))
             {
                 return;
             }

--- a/src/aws-cpp-sdk-core/source/internal/AWSHttpResourceClient.cpp
+++ b/src/aws-cpp-sdk-core/source/internal/AWSHttpResourceClient.cpp
@@ -406,8 +406,8 @@ namespace Aws
 
         void InitEC2MetadataClient()
         {
-            // The EC2 metadata client (used to fetch instance identity and IRSA-style
-            // credentials from the IMDS endpoint at 169.254.169.254) is disabled by
+            // The EC2 metadata client (used to fetch instance metadata and instance
+            // profile from the IMDS endpoint at 169.254.169.254) is disabled by
             // default and must be explicitly enabled by setting
             // FB_AWS_EC2_METADATA_CLIENT_ENABLED to a truthy value.
             if (!Aws::Utils::StringUtils::ConvertToBool(Aws::Environment::GetEnv("FB_AWS_EC2_METADATA_CLIENT_ENABLED").c_str()))


### PR DESCRIPTION
# Description

rename env var to FB_AWS_EC2_METADATA_CLIENT_ENABLED.

# Issue

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Renaming the env var is a breaking operational change for deployments still using `FIREBOLT_ALLOW_AWS_IRSA`; misconfiguration would leave EC2 IMDS/credential paths disabled.
> 
> **Overview**
> Renames the opt-in environment variable that controls whether `InitEC2MetadataClient` runs from `FIREBOLT_ALLOW_AWS_IRSA` to **`FB_AWS_EC2_METADATA_CLIENT_ENABLED`**. Behavior is unchanged: the EC2 metadata client stays off unless that variable is truthy.
> 
> Comments in `InitEC2MetadataClient` are updated to describe disabling IMDS (`169.254.169.254`) by default and enabling via the new name, instead of framing it as IRSA.
> 
> **Deploy note:** any runtime that still sets `FIREBOLT_ALLOW_AWS_IRSA` must switch to `FB_AWS_EC2_METADATA_CLIENT_ENABLED` or IMDS-based credentials/metadata will not initialize.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ce357c0d509944d35f37060589009cc86cde5203. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->